### PR TITLE
Finish the stack-safe idiomatic interpreter.

### DIFF
--- a/src/main/scala/transformers/Benchmarks.scala
+++ b/src/main/scala/transformers/Benchmarks.scala
@@ -24,6 +24,14 @@ class Benchmarks {
     Interpreter.runIdiomatic(0)(FreeState.pure(0).flatMap(loop))._1
   }
 
+  def leftAssociatedBindIdiomaticRec(bound: Int): Int = {
+    def loop(i: Int): FreeState[Int, Int] =
+      if (i > bound) FreeState.pure(i)
+      else FreeState.pure(i + 1).flatMap(loop)
+
+    Interpreter.runIdiomaticRec(0)(FreeState.pure(0).flatMap(loop))._1
+  }
+
   def leftAssociatedBindPlain(bound: Int): Int = {
     def loop(i: Int): State[Int, Int] =
       if (i > bound) State.pure(i)
@@ -64,6 +72,14 @@ class Benchmarks {
     Interpreter.runIdiomatic(0)(loop(0, FreeState.pure(0)))._1
   }
 
+  def getSetIdiomaticRec(bound: Int): Int = {
+    def loop(i: Int, acc: FreeState[Int, Int]): FreeState[Int, Int] =
+      if (i > bound) acc.flatMap(_ => FreeState.set(i)).flatMap(_ => FreeState.get)
+      else loop(i + 1, acc.flatMap(_ => FreeState.set(i)).flatMap(_ => FreeState.get))
+
+    Interpreter.runIdiomaticRec(0)(loop(0, FreeState.pure(0)))._1
+  }
+
   def getSetPlain(bound: Int): Int = {
     def loop(i: Int, acc: State[Int, Int]): State[Int, Int] =
       if (i > bound) acc.flatMap(_ => State.set(i)).flatMap(_ => State.get)
@@ -90,6 +106,13 @@ class Benchmarks {
 
   def effectfulTraversalIdiomatic(bound: Int): Int =
     Interpreter.runIdiomatic(0) {
+      FreeState.traverse((0 to bound).toList) { el =>
+        FreeState.get[Int].flatMap(s => FreeState.set(s + el))
+      }
+    }._1
+
+  def effectfulTraversalIdiomaticRec(bound: Int): Int =
+    Interpreter.runIdiomaticRec(0) {
       FreeState.traverse((0 to bound).toList) { el =>
         FreeState.get[Int].flatMap(s => FreeState.set(s + el))
       }
@@ -149,6 +172,33 @@ class Benchmarks {
   def leftAssociatedBindIdiomatic100k(): Int = leftAssociatedBindIdiomatic(100000)
   @Benchmark
   def leftAssociatedBindIdiomatic1mil(): Int = leftAssociatedBindIdiomatic(1000000)
+
+  @Benchmark
+  def effectfulTraversalIdiomaticRec1k(): Int = effectfulTraversalIdiomaticRec(1000)
+  @Benchmark
+  def effectfulTraversalIdiomaticRec10k(): Int = effectfulTraversalIdiomaticRec(10000)
+  @Benchmark
+  def effectfulTraversalIdiomaticRec100k(): Int = effectfulTraversalIdiomaticRec(100000)
+  @Benchmark
+  def effectfulTraversalIdiomaticRec1mil(): Int = effectfulTraversalIdiomaticRec(1000000)
+
+  @Benchmark
+  def getSetIdiomaticRec1k(): Int = getSetIdiomaticRec(1000)
+  @Benchmark
+  def getSetIdiomaticRec10k(): Int = getSetIdiomaticRec(10000)
+  @Benchmark
+  def getSetIdiomaticRec100k(): Int = getSetIdiomaticRec(100000)
+  @Benchmark
+  def getSetIdiomaticRec1mil(): Int = getSetIdiomaticRec(1000000)
+
+  @Benchmark
+  def leftAssociatedBindIdiomaticRec1k(): Int = leftAssociatedBindIdiomaticRec(1000)
+  @Benchmark
+  def leftAssociatedBindIdiomaticRec10k(): Int = leftAssociatedBindIdiomaticRec(10000)
+  @Benchmark
+  def leftAssociatedBindIdiomaticRec100k(): Int = leftAssociatedBindIdiomaticRec(100000)
+  @Benchmark
+  def leftAssociatedBindIdiomaticRec1mil(): Int = leftAssociatedBindIdiomaticRec(1000000)
 
   @Benchmark
   def effectfulTraversalOptimized1k(): Int = effectfulTraversalOptimized(1000)

--- a/src/main/scala/transformers/FreeState.scala
+++ b/src/main/scala/transformers/FreeState.scala
@@ -1,5 +1,8 @@
 package transformers
 
+import scalaz.Leibniz
+import scalaz.Leibniz.===
+
 sealed abstract class FreeState[S, A] { self =>
   def tag: Int
 
@@ -42,12 +45,20 @@ object FreeState {
     override final def tag = Tags.FlatMap
   }
 
-  final case class Get[S]() extends FreeState[S, S] {
+  final case class Get[S, A](ev: S === A) extends FreeState[S, A] {
     override final def tag = Tags.Get
   }
 
-  final case class Set[S](s: S) extends FreeState[S, Unit] {
+  object Get {
+    def apply[S](): FreeState[S, S] = Get[S, S](Leibniz.refl)
+  }
+
+  final case class Set[S, A](s: S, ev: Unit === A) extends FreeState[S, A] {
     override final def tag = Tags.Set
+  }
+
+  object Set {
+    def apply[S](s: S): FreeState[S, Unit] = Set[S, Unit](s, Leibniz.refl)
   }
 }
 
@@ -83,7 +94,7 @@ object Interpreter {
             currOp = conts.pollFirst()(res)
 
         case FreeState.Tags.Set =>
-          val op = currOp.asInstanceOf[FreeState.Set[S]]
+          val op = currOp.asInstanceOf[FreeState.Set[S, Unit]]
 
           state = op.s
           res = unit
@@ -108,7 +119,7 @@ object Interpreter {
               currOp = op.f(state)
 
             case FreeState.Tags.Set =>
-              val nested = op.fa.asInstanceOf[FreeState.Set[S]]
+              val nested = op.fa.asInstanceOf[FreeState.Set[S, Unit]]
 
               state = nested.s
               res = unit
@@ -124,38 +135,37 @@ object Interpreter {
     (state, res.asInstanceOf[A])
   }
 
-  // GADT shenanigans. This should be at some point the stack safe version.
-  // def runIdiomatic[S, A](s0: S)(fa0: FreeState[S, A]): (S, A) = {
-  //   @annotation.tailrec
-  //   def go(s: S, fa: FreeState[S, A]): (S, A) =
-  //     fa match {
-  //       case FreeState.Pure(a) =>
-  //         (s, a)
+  def runIdiomaticRec[S, A](s0: S)(fa0: FreeState[S, A]): (S, A) = {
+    @annotation.tailrec
+    def go(s: S, fa: FreeState[S, A]): (S, A) =
+      fa match {
+        case FreeState.Pure(a) =>
+          (s, a)
 
-  //       case FreeState.FlatMap(fa, f) =>
-  //         fa match {
-  //           case FreeState.Pure(a) =>
-  //             go(s, f(a))
+        case FreeState.FlatMap(fa, f) =>
+          fa match {
+            case FreeState.Pure(a) =>
+              go(s, f(a))
 
-  //           case FreeState.Get() =>
-  //             go(s, f(s))
+            case FreeState.Get(ev) =>
+              go(s, f(s))
 
-  //           case x: FreeState.Set[S] =>
-  //             go(x.s, f(()))
+            case FreeState.Set(s, ev) =>
+              go(s, f(()))
 
-  //           case FreeState.FlatMap(faInner, ff) =>
-  //             go(s, faInner.flatMap(x => ff(x).flatMap(f)))
-  //         }
+            case FreeState.FlatMap(faInner, ff) =>
+              go(s, faInner.flatMap(x => ff(x).flatMap(f)))
+          }
 
-  //       case FreeState.Get() =>
-  //         (s, s.asInstanceOf[A])
+        case FreeState.Get(ev) =>
+          (s, ev(s))
 
-  //       case FreeState.Set(s) =>
-  //         (s, ().asInstanceOf[A])
-  //     }
+        case FreeState.Set(s, ev) =>
+          (s, ev(()))
+      }
 
-  //   go(s0, fa0)
-  // }
+    go(s0, fa0)
+  }
 
   def runIdiomatic[S, A](s: S)(fa: FreeState[S, A]): (S, A) =
     fa match {
@@ -167,10 +177,10 @@ object Interpreter {
 
         runIdiomatic(s2)(flatmap.f(x))
 
-      case FreeState.Get() =>
-        (s, s.asInstanceOf[A])
+      case FreeState.Get(ev) =>
+        (s, ev(s))
 
-      case FreeState.Set(s) =>
-        (s, ().asInstanceOf[A])
+      case FreeState.Set(s, ev) =>
+        (s, ev(()))
     }
 }


### PR DESCRIPTION
I wonder how this one performs. I would guess slower than your optimized or (unsafe) idiomatic, but faster than Scalaz 7.3 (since with Scala 2.12.4 we can use varying type arguments in tailcalls).